### PR TITLE
migrate clap command from lioranboard

### DIFF
--- a/bot_brain.js
+++ b/bot_brain.js
@@ -1,5 +1,5 @@
 "use strict";
-const OBS = require("./obs_helper.js");
+const obs = require("./obs_helper.js");
 
 let matanbot_mention_count = 0;
 
@@ -39,7 +39,7 @@ const changeGreenScreenBackground = async (image_request) => {
   for(let image of images) {
     if (image_request === image.command_name) {
       try {
-        if(await OBS.switchGreenScreenBG(image.obs_name)) {
+        if(await obs.switchGreenScreenBG(image.obs_name)) {
           return `Background has been changed.`
         } else {
           return `Cannot change background right now.`
@@ -62,7 +62,7 @@ const message_main = async (user_info, user_msg) => {
   const user_command = user_msg.trim().toLowerCase();
 
   if (user_command.search("clap") != -1) {
-    OBS.showNewHeartEyes();
+    obs.showHeartEyes();
   }
   if (user_command.search("discord") != -1) {
     return "Did someone say discord? Join Matan's discord to get updates on stream schedule, juggling advice, hangout and all around have a good time! https://discord.gg/bNUaFRE";

--- a/obs_helper.js
+++ b/obs_helper.js
@@ -84,10 +84,10 @@ currently being shown.
 
 video is loop of a heart eyes emoji, hence the naming
 */
-const showNewHeartEyes = async () => {
+const showHeartEyes = async () => {
     const heart_scene = await getScene('hearts helper');
 
-    for(let source of heart_scene.sources) {
+    for (let source of heart_scene.sources) {
         if(!source.render) {
             //render source
             try {
@@ -112,4 +112,4 @@ const showNewHeartEyes = async () => {
     }
 }
 
-module.exports = { switchGreenScreenBG: switchGreenScreenBG, connect: connect, showNewHeartEyes: showNewHeartEyes }
+module.exports = { switchGreenScreenBG: switchGreenScreenBG, connect: connect, showHeartEyes: showHeartEyes }


### PR DESCRIPTION
OBS Websocket protocol:
https://github.com/Palakis/obs-websocket/blob/4.x-current/docs/generated/protocol.md

changes in obs_helper:
-added async function getScene, to factor it out, and not have code repeated. Looks through the OBS scene list and returns the scene data from the scene matching the scene_name parameter
-added showNewHeartEyes which has the new functionality. (see code comment for more info)
-added global variable current_scene and listen to OBS scene change event to keep updated
-deleted unused getScenes function
-minor style changes

Images to show the OBS setup. All 10 heart sources point to the same mp4 file. The point of having multiple is so the command can be used more than once every 4.5 seconds (length of the video). Can now handle 10 requests every 4.5 seconds, and more can be added in obs w/o changing the code.

![image](https://user-images.githubusercontent.com/13293015/103469197-8f13f080-4d16-11eb-9dfc-d9d48a39b8e5.png)
![image](https://user-images.githubusercontent.com/13293015/103469213-bb2f7180-4d16-11eb-9425-2b638fe459b2.png)


changes in bot_main:
-if 'clap' is a part of a user message, call showNewHeartEyes from obs_helper

